### PR TITLE
Fix Preconnect to Required Origins

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,11 +54,13 @@
     <meta property="og:image:height" content="315" />
     <meta property="og:url" content="https://coinprofit.app" />
 
-    <link rel="preconnect"  href="https://fonts.gstatic.com"/>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://ka-f.fontawesome.com"/>
-    <link rel="preconnect" href="https://www.youtube.com" />
-    <link rel="preconnect" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" />
+    <link rel="preconnect"  href="https://fonts.gstatic.com" crossorigin="anonymous"/>
+    <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin="anonymous"/>
+    <link rel="preconnect" href="https://ka-f.fontawesome.com" crossorigin="anonymous"/>
+    <link rel="preconnect" href="https://www.youtube.com" crossorigin="anonymous"/>
+    <link rel="preconnect" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" crossorigin="anonymous"/>
+
+    <link rel="preload" as="style"
 
     <link rel="icon" href="<%= BASE_URL %>favicon.png" />
     <title><%= htmlWebpackPlugin.options.title %></title>

--- a/public/index.html
+++ b/public/index.html
@@ -60,6 +60,8 @@
       href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
       rel="stylesheet"
     />
+    <link rel="preconnect"  href="https://fonts.gstatic.com"
+    <link rel="preload" href="https://fonts.googleapis.com" />
   </head>
   <body>
     <noscript

--- a/public/index.html
+++ b/public/index.html
@@ -60,8 +60,6 @@
     <link rel="preconnect" href="https://www.youtube.com" crossorigin="anonymous"/>
     <link rel="preconnect" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" crossorigin="anonymous"/>
 
-    <link rel="preload" as="style"
-
     <link rel="icon" href="<%= BASE_URL %>favicon.png" />
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link

--- a/public/index.html
+++ b/public/index.html
@@ -63,6 +63,7 @@
     <link rel="preconnect"  href="https://fonts.gstatic.com"/>
     <link rel="preload" href="https://fonts.googleapis.com" />
     <link rel="preload" href="https://ka-f.fontawesome.com"/>
+    <link rel="preload" href="https://www.youtube.com" />
   </head>
   <body>
     <noscript

--- a/public/index.html
+++ b/public/index.html
@@ -55,11 +55,11 @@
     <meta property="og:url" content="https://coinprofit.app" />
 
     <link rel="preconnect"  href="https://fonts.gstatic.com"/>
-    <link rel="preload" href="https://fonts.googleapis.com" />
-    <link rel="preload" href="https://ka-f.fontawesome.com"/>
-    <link rel="preload" href="https://www.youtube.com" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://ka-f.fontawesome.com"/>
+    <link rel="preconnect" href="https://www.youtube.com" />
     <link rel="preconnect" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" />
-    
+
     <link rel="icon" href="<%= BASE_URL %>favicon.png" />
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link

--- a/public/index.html
+++ b/public/index.html
@@ -60,8 +60,9 @@
       href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
       rel="stylesheet"
     />
-    <link rel="preconnect"  href="https://fonts.gstatic.com"
+    <link rel="preconnect"  href="https://fonts.gstatic.com"/>
     <link rel="preload" href="https://fonts.googleapis.com" />
+    <link rel="preload" href="https://ka-f.fontawesome.com"/>
   </head>
   <body>
     <noscript

--- a/public/index.html
+++ b/public/index.html
@@ -54,16 +54,18 @@
     <meta property="og:image:height" content="315" />
     <meta property="og:url" content="https://coinprofit.app" />
 
+    <link rel="preconnect"  href="https://fonts.gstatic.com"/>
+    <link rel="preload" href="https://fonts.googleapis.com" />
+    <link rel="preload" href="https://ka-f.fontawesome.com"/>
+    <link rel="preload" href="https://www.youtube.com" />
+    <link rel="preconnect" href="https://unpkg.com/nprogress@0.2.0/nprogress.css" />
+    
     <link rel="icon" href="<%= BASE_URL %>favicon.png" />
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link
       href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
       rel="stylesheet"
     />
-    <link rel="preconnect"  href="https://fonts.gstatic.com"/>
-    <link rel="preload" href="https://fonts.googleapis.com" />
-    <link rel="preload" href="https://ka-f.fontawesome.com"/>
-    <link rel="preload" href="https://www.youtube.com" />
   </head>
   <body>
     <noscript


### PR DESCRIPTION
# Fix Preconnect

## Problem
In the project, there is need to connect to google fonts servers for fonts, fontawesome servers for icons and other third party origins for needed resources. These requests to these servers impact page speed. According to [web.dev](https://web.dev/uses-rel-preconnect/?utm_source=lighthouse&utm_medium=devtools), 
> Establishing connections often involves significant time in slow networks, particularly when it comes to secure connections, as it may involve DNS lookups, redirects, and several round trips to the final server that handles the user's request.

## Solution
In the Lighthouse audit, the speed index of coinprofit.app is 2.9s. However, by adding `<link rel="preconnect">` the speed index became 2.1s giving us 0.8s gain in speed, which is 17% improvement in performance. The `<link rel="preconnect">` takes care of the DNS lookups, redirects and other round trips to the server thus making the
> application feel much snappier to the user without negatively affecting the use of bandwidth.

## Others
Find below a copy of the report before and after the solution was implemented.
[lighthouse_coinprofit_desktop.pdf](https://github.com/chaderenyore/coinprofit/files/8452990/lighthouse_coinprofit_desktop.pdf)
[fix_preconnect.pdf](https://github.com/chaderenyore/coinprofit/files/8452995/fix_preconnect.pdf)

You will notice that this solution also
- reduce total blocking time and that makes sense because the round trips to the server blocks the load event.
